### PR TITLE
Use $EDITOR as editor for notes if it is set

### DIFF
--- a/_helpers/helpers.sh
+++ b/_helpers/helpers.sh
@@ -85,7 +85,13 @@ function previewnotes {
 
 }
 
-
+function opennote {
+  if [ -z "$EDITOR" ]; then
+    open $1
+  else
+    eval "$EDITOR $1"
+  fi
+}
 
 # help
 # --------------------------------------------------

--- a/bin/notes
+++ b/bin/notes
@@ -125,7 +125,7 @@ while getopts "$optstring" opt; do
     n)
       checkname "$OPTARG"
       mkdir -p $(dirname "$OPTARG${_ext}") && touch "$OPTARG${_ext}"
-      open "$OPTARG${_ext}"
+      opennote "$OPTARG${_ext}"
       exit 0
     ;;
 
@@ -215,7 +215,7 @@ if [ -z "$2" ]; then
     exit 0
   fi
 
-  open $1${_ext}
+  opennote $1${_ext}
   exit 0
 fi
 


### PR DESCRIPTION
Adds an `opennote` helper function that will open as usual or using $EDITOR environment variable if it is set to select editor.

It gets a bit annoying to open Markdown files in Xcode by default when you're not using it.